### PR TITLE
Fix: unknown identifier error

### DIFF
--- a/credhub/auth/example_test.go
+++ b/credhub/auth/example_test.go
@@ -7,7 +7,7 @@ import (
 	"code.cloudfoundry.org/credhub-cli/credhub/auth"
 )
 
-func ExampleOAuth() {
+func ExampleAuth() {
 	_ = func() {
 		// To retrieve the access token from the CredHub client, use type assertion
 		ch, err := credhub.New(


### PR DESCRIPTION
- As seen in `pipelines/credhub-cli/jobs/update-go-modules/builds/34`, next update of go and go modules causes compliation error as follows:
```
go run -mod=mod github.com/onsi/ginkgo/v2/ginkgo -r --randomize-suites --randomize-all --race -p 2>&1
go: downloading github.com/onsi/ginkgo/v2 v2.22.2
go: downloading golang.org/x/tools v0.30.0
go: downloading github.com/go-task/slim-sprig/v3 v3.0.0
go: downloading github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572
go: downloading github.com/google/pprof v0.0.0-20250208200701-d0013a598941
Failed to compile auth:
# code.cloudfoundry.org/credhub-cli/credhub/auth_test
# [code.cloudfoundry.org/credhub-cli/credhub/auth_test]
./example_test.go:10:1: ExampleOAuth refers to unknown identifier: OAuth
```
- Do not know exactly what causes the error but chaning the function name resolves the error.
- Changing the function name so next `update-go-modules` job build can pass.