### PR TITLE
Regenerate certificate with keylength

### DIFF
--- a/commands/regenerate_test.go
+++ b/commands/regenerate_test.go
@@ -55,9 +55,8 @@ var _ = Describe("Regenerate", func() {
 
 			session := runCommand("regenerate", "--name", "my-password-stuffs", "--output-json")
 
-			content := string(session.Out.Contents())
 			Eventually(session).Should(Exit(0))
-			Expect(content).To(MatchJSON(fmt.Sprintf(defaultResponseJSON, "password", "my-password-stuffs", `"<redacted>"`, `{}`)))
+			Expect(string(session.Out.Contents())).To(MatchJSON(fmt.Sprintf(defaultResponseJSON, "password", "my-password-stuffs", `"<redacted>"`, `{}`)))
 		})
 
 		It("prints error when server returns an error", func() {
@@ -166,8 +165,7 @@ metadata:
 			session := runCommand("regenerate", "--name", "/my-certificate", "--output-json")
 
 			Eventually(session).Should(Exit(0))
-			content := string(session.Out.Contents())
-			Expect(content).To(MatchJSON(fmt.Sprintf(defaultResponseJSON, "certificate", "/my-certificate", `"<redacted>"`, `{}`)))
+			Expect(string(session.Out.Contents())).To(MatchJSON(fmt.Sprintf(defaultResponseJSON, "certificate", "/my-certificate", `"<redacted>"`, `{}`)))
 		})
 		It("prints error when server returns an error", func() {
 			server.RouteToHandler("POST", "/api/v1/data",

--- a/credhub/credentials/regenerate/types.go
+++ b/credhub/credentials/regenerate/types.go
@@ -1,0 +1,14 @@
+// CredHub credential types for regenerating credentials
+package regenerate
+
+type Password struct{}
+
+type User struct{}
+
+type Certificate struct {
+	KeyLength int `json:"key_length"`
+}
+
+type RSA struct{}
+
+type SSH struct{}

--- a/credhub/regenerate.go
+++ b/credhub/regenerate.go
@@ -11,8 +11,9 @@ import (
 type RegenerateOption func(options *RegenerateOptions) error
 
 type regenerateRequest struct {
-	Name       string `json:"name"`
-	Regenerate bool   `json:"regenerate"`
+	Name       string      `json:"name"`
+	Regenerate bool        `json:"regenerate"`
+	Parameters interface{} `json:"parameters,omitempty"`
 	RegenerateOptions
 }
 
@@ -21,12 +22,13 @@ type RegenerateOptions struct {
 }
 
 // Regenerate generates and returns a new credential version using the same parameters as the existing credential. The returned credential may be of any type.
-func (ch *CredHub) Regenerate(name string, options ...RegenerateOption) (credentials.Credential, error) {
+func (ch *CredHub) Regenerate(name string, gen interface{}, options ...RegenerateOption) (credentials.Credential, error) {
 	var cred credentials.Credential
 
 	request := regenerateRequest{
 		Name:       name,
 		Regenerate: true,
+		Parameters: gen,
 	}
 
 	for _, option := range options {

--- a/credhub/regenerate_test.go
+++ b/credhub/regenerate_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 
 	. "code.cloudfoundry.org/credhub-cli/credhub"
+	"code.cloudfoundry.org/credhub-cli/credhub/credentials/regenerate"
 )
 
 var _ = Describe("Regenerate", func() {
@@ -20,8 +21,7 @@ var _ = Describe("Regenerate", func() {
 		}}
 
 		ch, _ := New("https://example.com", Auth(dummyAuth.Builder()), ServerVersion("2.6.0"))
-
-		ch.Regenerate("/example-password")
+		ch.Regenerate("/example-password", regenerate.Password{})
 		url := dummyAuth.Request.URL.String()
 		Expect(url).To(Equal("https://example.com/api/v1/data"))
 		Expect(dummyAuth.Request.Method).To(Equal(http.MethodPost))
@@ -49,8 +49,7 @@ var _ = Describe("Regenerate", func() {
 			}}
 
 			ch, _ := New("https://example.com", Auth(dummyAuth.Builder()), ServerVersion("2.6.0"))
-
-			cred, err := ch.Regenerate("/example-password")
+			cred, err := ch.Regenerate("/example-password", regenerate.Password{})
 			Expect(err).To(BeNil())
 			Expect(cred.Id).To(Equal("some-id"))
 			Expect(cred.Name).To(Equal("/example-password"))
@@ -67,7 +66,7 @@ var _ = Describe("Regenerate", func() {
 			}}
 
 			ch, _ := New("https://example.com", Auth(dummyAuth.Builder()), ServerVersion("2.6.0"))
-			_, err := ch.Regenerate("/example-password")
+			_, err := ch.Regenerate("/example-password", regenerate.Password{})
 
 			Expect(err).To(HaveOccurred())
 		})


### PR DESCRIPTION
Hi, as mentioned by https://github.com/cloudfoundry/credhub/pull/870#issuecomment-2740987446, I've created a proposal for using parameters, e.g. key-length in this case, in the process of regenerating credentials. 

**Assumption:**
For introducing this feature, I've assumed that the approach for generating credentials could be reused within the regenerating process.